### PR TITLE
[feature & refator] api 데이터 가공 관련

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,13 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("kotlin-parcelize")
 }
+
+val properties = Properties()
+properties.load(project.rootProject.file("local.properties").inputStream())
 
 android {
     namespace = "com.example.meohaji"
@@ -16,6 +21,7 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "YOUTUBE_API_KEY", properties.getProperty("YOUTUBE_API_KEY"))
     }
 
     buildTypes {
@@ -36,6 +42,7 @@ android {
     }
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
 }
 

--- a/app/src/main/java/com/example/meohaji/CategoryVideoAdapter.kt
+++ b/app/src/main/java/com/example/meohaji/CategoryVideoAdapter.kt
@@ -11,18 +11,23 @@ import com.example.meohaji.databinding.LayoutVideoByCategoryBigBinding
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import kotlin.math.round
 
-class CategoryVideoAdapter(private val context: Context): ListAdapter<CategoryVideo, CategoryVideoAdapter.CategoryVideoViewHolder>(
-    object : DiffUtil.ItemCallback<CategoryVideo>() {
-        override fun areItemsTheSame(oldItem: CategoryVideo, newItem: CategoryVideo): Boolean {
-            return oldItem.id == newItem.id
-        }
+class CategoryVideoAdapter(private val context: Context) :
+    ListAdapter<CategoryVideo, CategoryVideoAdapter.CategoryVideoViewHolder>(
+        object : DiffUtil.ItemCallback<CategoryVideo>() {
+            override fun areItemsTheSame(oldItem: CategoryVideo, newItem: CategoryVideo): Boolean {
+                return oldItem.id == newItem.id
+            }
 
-        override fun areContentsTheSame(oldItem: CategoryVideo, newItem: CategoryVideo): Boolean {
-            return oldItem == newItem
+            override fun areContentsTheSame(
+                oldItem: CategoryVideo,
+                newItem: CategoryVideo
+            ): Boolean {
+                return oldItem == newItem
+            }
         }
-    }
-) {
+    ) {
 
     val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX", Locale.getDefault())
     val outputFormat = SimpleDateFormat("yyyy.MM.dd HH:mm", Locale.getDefault())
@@ -41,7 +46,8 @@ class CategoryVideoAdapter(private val context: Context): ListAdapter<CategoryVi
         holder.onBind(currentList[position])
     }
 
-    inner class CategoryVideoViewHolder(private val binding: LayoutVideoByCategoryBigBinding): RecyclerView.ViewHolder(binding.root) {
+    inner class CategoryVideoViewHolder(private val binding: LayoutVideoByCategoryBigBinding) :
+        RecyclerView.ViewHolder(binding.root) {
         fun onBind(item: CategoryVideo) = with(binding) {
             Glide.with(context)
                 .load(item.thumbnail)
@@ -50,6 +56,29 @@ class CategoryVideoAdapter(private val context: Context): ListAdapter<CategoryVi
             tvVideoTitle.text = item.title
             tvChannelName.text = item.channelTitle
             tvUploadDate.text = outputFormat.format(inputFormat.parse(item.publishedAt) as Date)
+            textView4.text = calRecomandScore(
+                item.description,
+                item.viewCount,
+                item.likeCount,
+                item.commentCount
+            )
         }
+    }
+
+    fun calRecomandScore(
+        description: String,
+        viewCount: Int,
+        likeCount: Int,
+        commentCount: Int
+    ): String {
+        val viewScore = viewCount * 0.5 * (1.0 / viewCount.toString().length)
+        val likeScore = likeCount * 0.3 * (1.0 / likeCount.toString().length)
+        val commentScore = commentCount * 0.2 * (1.0 / commentCount.toString().length)
+        val isShorts = description.contains("shorts")
+
+        var totalScore =
+            if (isShorts) (viewScore + likeScore + commentScore) / viewScore * 3.3 * 1.5 else (viewScore + likeScore + commentScore) / viewScore * 3.3
+        totalScore = round(totalScore * 10) / 10
+        return if (totalScore > 5.0) "5.0" else totalScore.toString()
     }
 }

--- a/app/src/main/java/com/example/meohaji/YoutubeCategory.kt
+++ b/app/src/main/java/com/example/meohaji/YoutubeCategory.kt
@@ -9,13 +9,11 @@ enum class YoutubeCategory(
     MUSIC("음악", "10"),
     PETS_ANIMALS("애완동물 & 동물", "15"),
     SPORTS("스포츠", "17"),
-    TRAVEL_EVENTS("여행 & 행사", "19"),
     GAMING("게임", "20"),
     PEOPLE_BLOGS("일상 & 브이로그", "22"),
     COMEDY("코미디", "23"),
     ENTERTAINMENT("엔터테인먼트", "24"),
     NEWS_POLITICS("뉴스 & 정치", "25"),
     HOWTO_STYLE("정보 & 스타일", "26"),
-    EDUCATION("교육", "27"),
     SCIENCE_TECHNOLOGY("과학 & 기술", "28"),
 }

--- a/app/src/main/java/com/example/meohaji/fragment/HomeFragment.kt
+++ b/app/src/main/java/com/example/meohaji/fragment/HomeFragment.kt
@@ -13,6 +13,7 @@ import android.widget.Toast
 import androidx.activity.addCallback
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import com.example.meohaji.BuildConfig
 import com.example.meohaji.CategoryChannel
 import com.example.meohaji.CategoryChannelAdapter
 import com.example.meohaji.CategoryVideo
@@ -212,15 +213,15 @@ class HomeFragment : Fragment() {
     }
 
     private suspend fun getMostPopularVideos() = withContext(Dispatchers.IO) {
-        apiService.mostPopularVideos("본인 API 키 채우기", "snippet,statistics", "mostPopular", "kr")
+        apiService.mostPopularVideos(BuildConfig.YOUTUBE_API_KEY, "snippet,statistics", "mostPopular", "kr")
     }
 
     private suspend fun getVideoByCategory(id: String) = withContext(Dispatchers.IO) {
-        apiService.videoByCategory("본인 API 키 채우기", "snippet,statistics", "mostPopular", 10, "kr", id)
+        apiService.videoByCategory(BuildConfig.YOUTUBE_API_KEY, "snippet,statistics", "mostPopular", 10, "kr", id)
     }
 
     private suspend fun getChannelByCategory(id: String) = withContext(Dispatchers.IO) {
-        apiService.channelByCategory("본인 API 키 채우기", "snippet,statistics", id)
+        apiService.channelByCategory(BuildConfig.YOUTUBE_API_KEY, "snippet,statistics", id)
     }
 
     private fun overrideBackAction() {


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [ ] 버그픽스
- [x] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃

## 변경사항 작성
변경사항의 상세 정보를 작성해주세요.

-기능
1. 개인 api키를 쓸 수 있게 구성
2. 영상제작 추천 점수 계산 추가
3. 사용할 수 없는 유튜브 카테고리 제거
-설명
1. 기존에는 직접 api키를 입력하여 사용했다.
하지만 .gitignore에 들어있는 local.properties에 개인 api 키를 저장하고 이를 build.gradle에서 불러와 BuildConfig에 넣어 사용하는 형식으로 변경
2. 통계자료에 있는 좋아요수, 조회수, 댓글수, 쇼츠여부를 활용하여 영상제작 추천 점수를 부여함
현재는 어댑터에서 계산을 하지만 이후 상세 페이지로 데이터를 옮길 것을 생각하면 데이터를 받아올 때부터 계산하여 변수로 넣어주게 될 거 같음
3. enum class로 만든 유튜브 카테고리에서 제대로 결과 데이터를 가져오지 못하는 카테고리를 찾아 제거