### PR TITLE
[refactor & layout] : Home 프래그먼트 관련

### DIFF
--- a/app/src/main/java/com/example/meohaji/HomeAdapter.kt
+++ b/app/src/main/java/com/example/meohaji/HomeAdapter.kt
@@ -1,0 +1,196 @@
+package com.example.meohaji
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.example.meohaji.databinding.SetChannelByCategoryBinding
+import com.example.meohaji.databinding.SetMostPopularVideoBinding
+import com.example.meohaji.databinding.SetSelectCategoryBinding
+import com.example.meohaji.databinding.SetThemeTitleBinding
+import com.example.meohaji.databinding.SetVideoByCategoryBinding
+import com.google.android.material.R
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class HomeAdapter(private val context: Context) :
+    ListAdapter<HomeUiData, RecyclerView.ViewHolder>(object : DiffUtil.ItemCallback<HomeUiData>() {
+        override fun areItemsTheSame(oldItem: HomeUiData, newItem: HomeUiData): Boolean {
+            return oldItem === newItem
+        }
+
+        override fun areContentsTheSame(oldItem: HomeUiData, newItem: HomeUiData): Boolean {
+            return oldItem == newItem
+        }
+
+    }) {
+
+        interface CommunicateVideoByCategory {
+            fun call(id: String)
+        }
+
+    var communicateVideoByCategory: CommunicateVideoByCategory? = null
+
+    private var categorySpinnerIdx = 0
+
+    val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX", Locale.getDefault())
+    val outputFormat = SimpleDateFormat("yyyy.MM.dd HH:mm", Locale.getDefault())
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            CHANNEL -> {
+                CategoryChannelViewHolder(
+                    SetChannelByCategoryBinding.inflate(
+                        LayoutInflater.from(
+                            parent.context
+                        ), parent, false
+                    )
+                )
+            }
+
+            VIDEO -> {
+                CategoryVideoViewHolder(
+                    SetVideoByCategoryBinding.inflate(
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
+                )
+            }
+
+            POPULARVIDEO -> {
+                MostPopularVideoViewHolder(
+                    SetMostPopularVideoBinding.inflate(
+                        LayoutInflater.from(
+                            parent.context
+                        ), parent, false
+                    )
+                )
+            }
+
+            SPINNER -> {
+                SpinnerViewHolder(
+                    SetSelectCategoryBinding.inflate(
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
+                )
+            }
+
+            else -> {
+                TitleViewHolder(
+                    SetThemeTitleBinding.inflate(
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
+                )
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (currentList[position]) {
+            is HomeUiData.Title -> (holder as TitleViewHolder).bind(currentList[position] as HomeUiData.Title)
+            is HomeUiData.CategoryChannels -> (holder as CategoryChannelViewHolder).bind(currentList[position] as HomeUiData.CategoryChannels)
+            is HomeUiData.CategoryVideos -> (holder as CategoryVideoViewHolder).bind(currentList[position] as HomeUiData.CategoryVideos)
+            is HomeUiData.MostPopularVideos -> (holder as MostPopularVideoViewHolder).bind(
+                currentList[position] as HomeUiData.MostPopularVideos
+            )
+
+            is HomeUiData.Spinner -> (holder as SpinnerViewHolder).bind(currentList[position] as HomeUiData.Spinner)
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (currentList[position]) {
+            is HomeUiData.CategoryChannels -> CHANNEL
+            is HomeUiData.CategoryVideos -> VIDEO
+            is HomeUiData.MostPopularVideos -> POPULARVIDEO
+            is HomeUiData.Spinner -> SPINNER
+            is HomeUiData.Title -> TITLE
+        }
+    }
+
+    companion object {
+        private const val CHANNEL = 1
+        private const val VIDEO = 2
+        private const val POPULARVIDEO = 3
+        private const val SPINNER = 4
+        private const val TITLE = 5
+    }
+
+    inner class CategoryChannelViewHolder(private val binding: SetChannelByCategoryBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: HomeUiData.CategoryChannels) {
+            val categoryChannelAdapter = CategoryChannelAdapter(context)
+            binding.rvHomeCategoryChannel.adapter = categoryChannelAdapter
+            categoryChannelAdapter.submitList(item.list.toList())
+        }
+    }
+
+    inner class CategoryVideoViewHolder(private val binding: SetVideoByCategoryBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: HomeUiData.CategoryVideos) = with(binding) {
+            Glide.with(context)
+                .load(item.video.thumbnail)
+                .into(ivThumbnail)
+
+            tvVideoTitle.text = item.video.title
+            tvChannelName.text = item.video.channelTitle
+            tvUploadDate.text =
+                outputFormat.format(inputFormat.parse(item.video.publishedAt) as Date)
+            textView4.text = item.video.recommendScore.toString()
+        }
+    }
+
+    inner class MostPopularVideoViewHolder(private val binding: SetMostPopularVideoBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: HomeUiData.MostPopularVideos) {
+            val mostPopularVideoAdapter = MostPopularVideoAdapter(context)
+            binding.rvHomeMostPopularVideo.adapter = mostPopularVideoAdapter
+            mostPopularVideoAdapter.submitList(item.list.toList())
+        }
+    }
+
+    inner class SpinnerViewHolder(private val binding: SetSelectCategoryBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: HomeUiData.Spinner) {
+            val adapter1 = ArrayAdapter(
+                context,
+                R.layout.support_simple_spinner_dropdown_item,
+                item.categories
+            )
+            binding.spinnerHomeCategory.adapter = adapter1
+
+            binding.spinnerHomeCategory.setSelection(categorySpinnerIdx)
+            binding.spinnerHomeCategory.onItemSelectedListener =
+                object : AdapterView.OnItemSelectedListener {
+                    override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
+                        if (categorySpinnerIdx != p2) communicateVideoByCategory?.call(YoutubeCategory.entries[p2].id)
+
+                        categorySpinnerIdx = p2
+                    }
+
+                    override fun onNothingSelected(p0: AdapterView<*>?) {
+                        TODO("Not yet implemented")
+                    }
+                }
+        }
+    }
+
+    inner class TitleViewHolder(private val binding: SetThemeTitleBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: HomeUiData.Title) {
+            binding.tvHomeTitle.text = item.title
+        }
+    }
+}

--- a/app/src/main/java/com/example/meohaji/HomeUiData.kt
+++ b/app/src/main/java/com/example/meohaji/HomeUiData.kt
@@ -1,0 +1,23 @@
+package com.example.meohaji
+
+sealed class HomeUiData {
+    data class Title(
+        val title: String
+    ): HomeUiData()
+
+    data class MostPopularVideos(
+        val list: List<MostPopularVideo>
+    ): HomeUiData()
+
+    data class CategoryChannels(
+        val list: List<CategoryChannel>
+    ): HomeUiData()
+
+    data class CategoryVideos(
+        val video: CategoryVideo
+    ): HomeUiData()
+
+    data class Spinner(
+        val categories: List<String>
+    ): HomeUiData()
+}

--- a/app/src/main/java/com/example/meohaji/NetworkInterface.kt
+++ b/app/src/main/java/com/example/meohaji/NetworkInterface.kt
@@ -1,5 +1,6 @@
 package com.example.meohaji
 
+import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -7,27 +8,27 @@ import retrofit2.http.Query
 interface NetworkInterface {
 
     @GET("videos")
-    suspend fun mostPopularVideos(
+    fun mostPopularVideos(
         @Query("key") key: String?,
         @Query("part") part: String?,
         @Query("chart") chart: String?,
         @Query("regionCode") code: String?
-    ): Video
+    ): Call<Video?>?
 
     @GET("videos")
-    suspend fun videoByCategory(
+    fun videoByCategory(
         @Query("key") key: String?,
         @Query("part") part: String?,
         @Query("chart") chart: String?,
         @Query("maxResults") max: Int?,
         @Query("regionCode") code: String?,
         @Query("videoCategoryId") categoryId: String?,
-    ): Video
+    ): Call<Video?>?
 
     @GET("channels")
-    suspend fun channelByCategory(
+    fun channelByCategory(
         @Query("key") key: String?,
         @Query("part") part: String?,
         @Query("id") channelId: String?
-    ) : Channel
+    ) : Call<Channel?>?
 }

--- a/app/src/main/java/com/example/meohaji/fragment/HomeFragment.kt
+++ b/app/src/main/java/com/example/meohaji/fragment/HomeFragment.kt
@@ -3,6 +3,7 @@ package com.example.meohaji.fragment
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -18,16 +19,25 @@ import com.example.meohaji.CategoryChannel
 import com.example.meohaji.CategoryChannelAdapter
 import com.example.meohaji.CategoryVideo
 import com.example.meohaji.CategoryVideoAdapter
+import com.example.meohaji.Channel
+import com.example.meohaji.HomeAdapter
+import com.example.meohaji.HomeUiData
 import com.example.meohaji.MostPopularVideo
 import com.example.meohaji.MostPopularVideoAdapter
 import com.example.meohaji.NetworkClient.apiService
-import com.example.meohaji.SortOrder
+import com.example.meohaji.SeachAdapter
+import com.example.meohaji.SeachList
+import com.example.meohaji.Video
 import com.example.meohaji.YoutubeCategory
 import com.example.meohaji.databinding.FragmentHomeBinding
+import com.google.android.material.R
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 import kotlin.math.round
 
 class HomeFragment : Fragment() {
@@ -47,6 +57,10 @@ class HomeFragment : Fragment() {
 
     private val categoryVideoAdapter by lazy {
         CategoryVideoAdapter(requireContext())
+    }
+
+    private val homeAdapter by lazy {
+        HomeAdapter(requireContext())
     }
 
     private val categoryList = listOf(
@@ -74,16 +88,31 @@ class HomeFragment : Fragment() {
     )
 
     private val mostPopularVideoList = arrayListOf<MostPopularVideo>()
-    private val _mostPopularVideos = MutableLiveData<List<MostPopularVideo>>()
-    private val mostPopularVideos: LiveData<List<MostPopularVideo>> get() = _mostPopularVideos
+//    private val _mostPopularVideos = MutableLiveData<List<MostPopularVideo>>()
+//    private val mostPopularVideos: LiveData<List<MostPopularVideo>> get() = _mostPopularVideos
 
-    private val videoByCategoryList = arrayListOf<CategoryVideo>()
-    private val _videoByCategory = MutableLiveData<List<CategoryVideo>>()
-    private val videoByCategory: LiveData<List<CategoryVideo>> get() = _videoByCategory
+    private val videoByCategoryList = arrayListOf<HomeUiData.CategoryVideos>()
+//    private val _videoByCategory = MutableLiveData<List<CategoryVideo>>()
+//    private val videoByCategory: LiveData<List<CategoryVideo>> get() = _videoByCategory
 
     private val channelByCategoryList = arrayListOf<CategoryChannel>()
-    private val _channelByCategory = MutableLiveData<List<CategoryChannel>>()
-    private val channelByCategory: LiveData<List<CategoryChannel>> get() = _channelByCategory
+//    private val _channelByCategory = MutableLiveData<List<CategoryChannel>>()
+//    private val channelByCategory: LiveData<List<CategoryChannel>> get() = _channelByCategory
+
+    private val list = arrayListOf<HomeUiData>(
+        HomeUiData.Title("지금 가장 인기있는 영상 TOP5"),
+        HomeUiData.MostPopularVideos(list = arrayListOf()),
+        HomeUiData.Spinner(YoutubeCategory.entries.map { it.str }),
+        HomeUiData.Title("해당 카테고리 채널"),
+        HomeUiData.CategoryChannels(list = arrayListOf()),
+        HomeUiData.Title("카테고리 인기 영상"),
+    )
+
+    private var clear1 = true
+    private var _clear2 = MutableLiveData<Boolean>()
+    private val clear2: LiveData<Boolean> get() = _clear2
+    private var clear3 = false
+    val channelIds = StringBuilder()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -97,92 +126,91 @@ class HomeFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
         communicateMostPopularVideos()
+        communicateVideoByCategory("1")
 
-        binding.rvHomeMostPopularVideo.adapter = mostPopularVideoAdapter
-        mostPopularVideoAdapter.videoClick = object : MostPopularVideoAdapter.MostPopularVideoClick {
-            override fun onClick(videoData: MostPopularVideo) {
-
-            }
-
-        }
-
-        binding.rvHomeCategoryChannel.adapter = categoryChannelAdapter
-
-        binding.rvHomeCategoryVideo.adapter = categoryVideoAdapter
-        categoryVideoAdapter.videoClick = object : CategoryVideoAdapter.CategoryVideoClick {
-            override fun onClick(videoData: CategoryVideo) {
-
+        binding.rvHome.adapter = homeAdapter
+        homeAdapter.communicateVideoByCategory = object : HomeAdapter.CommunicateVideoByCategory {
+            override fun call(id: String) {
+                _clear2.value = false
+                clear3 = false
+                communicateVideoByCategory(id)
             }
         }
 
-        val adapter1 = ArrayAdapter(
-            requireContext(),
-            com.google.android.material.R.layout.support_simple_spinner_dropdown_item,
-            YoutubeCategory.entries.map { it.str }
-        )
-        binding.spinnerHomeCategory.adapter = adapter1
+        clear2.observe(viewLifecycleOwner) {
+            if (it) {
+                apiService.channelByCategory(
+                    BuildConfig.YOUTUBE_API_KEY,
+                    "snippet,statistics",
+                    channelIds.toString()
+                )
+                    ?.enqueue(object : Callback<Channel?> {
+                        override fun onResponse(
+                            call: Call<Channel?>,
+                            response: Response<Channel?>
+                        ) {
+                            channelByCategoryList.clear()
+                            response.body()?.items?.forEach { item ->
+                                channelByCategoryList.add(
+                                    CategoryChannel(
+                                        item.id,
+                                        item.snippet.title,
+                                        item.snippet.thumbnails.medium.url
+                                    )
+                                )
+                            }
 
-        val adapter2 = ArrayAdapter(
-            requireContext(),
-            com.google.android.material.R.layout.support_simple_spinner_dropdown_item,
-            SortOrder.entries.map { it.str }
-        )
-        binding.spinnerHomeSortVideo.adapter = adapter2
+                            clear3 = true
+                            checkComplete()
+                        }
 
-        binding.spinnerHomeCategory.onItemSelectedListener =
-            object : AdapterView.OnItemSelectedListener {
-                override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
-                    communicateVideoByCategory(YoutubeCategory.entries[p2].id)
-                }
-
-                override fun onNothingSelected(p0: AdapterView<*>?) {
-                    TODO("Not yet implemented")
-                }
-
+                        override fun onFailure(call: Call<Channel?>, t: Throwable) {
+                            Log.e("#heesoo", "onFailure: ${t.message}")
+                        }
+                    })
             }
-
-        binding.spinnerHomeSortVideo.onItemSelectedListener =
-            object : AdapterView.OnItemSelectedListener {
-                override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
-                    when (p2) {
-                        0 -> {
-                            videoByCategoryList.sortByDescending { it.recommendScore }
-                        }
-
-                        1 -> {
-                            videoByCategoryList.sortByDescending { it.viewCount }
-                        }
-
-                        2 -> {
-                            videoByCategoryList.sortByDescending { it.likeCount }
-                        }
-
-                        else -> {
-                            videoByCategoryList.sortBy { it.publishedAt }
-                        }
-                    }
-
-                    _videoByCategory.value = videoByCategoryList
-                }
-
-                override fun onNothingSelected(p0: AdapterView<*>?) {
-                    TODO("Not yet implemented")
-                }
-
-            }
-
-        mostPopularVideos.observe(viewLifecycleOwner) {
-            mostPopularVideoAdapter.submitList(it.toList())
         }
 
-        videoByCategory.observe(viewLifecycleOwner) {
-            categoryVideoAdapter.submitList(it.toList())
-        }
+//        val adapter2 = ArrayAdapter(
+//            requireContext(),
+//            com.google.android.material.R.layout.support_simple_spinner_dropdown_item,
+//            SortOrder.entries.map { it.str }
+//        )
+//        binding.spinnerHomeSortVideo.adapter = adapter2
+//
 
-        channelByCategory.observe(viewLifecycleOwner) {
-            categoryChannelAdapter.submitList(it.toList())
-        }
+//
+//        binding.spinnerHomeSortVideo.onItemSelectedListener =
+//            object : AdapterView.OnItemSelectedListener {
+//                override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
+//                    when (p2) {
+//                        0 -> {
+//                            videoByCategoryList.sortByDescending { it.recommendScore }
+//                        }
+//
+//                        1 -> {
+//                            videoByCategoryList.sortByDescending { it.viewCount }
+//                        }
+//
+//                        2 -> {
+//                            videoByCategoryList.sortByDescending { it.likeCount }
+//                        }
+//
+//                        else -> {
+//                            videoByCategoryList.sortBy { it.publishedAt }
+//                        }
+//                    }
+//
+//                    _videoByCategory.value = videoByCategoryList
+//                }
+//
+//                override fun onNothingSelected(p0: AdapterView<*>?) {
+//                    TODO("Not yet implemented")
+//                }
+//
+//            }
     }
 
     override fun onDestroyView() {
@@ -191,11 +219,17 @@ class HomeFragment : Fragment() {
     }
 
     private fun communicateMostPopularVideos() {
-        CoroutineScope(Dispatchers.Main).launch {
-            runCatching {
-                val videos = getMostPopularVideos()
+        clear1 = false
+
+        apiService.mostPopularVideos(
+            BuildConfig.YOUTUBE_API_KEY,
+            "snippet,statistics",
+            "mostPopular",
+            "kr"
+        )?.enqueue(object : Callback<Video?> {
+            override fun onResponse(call: Call<Video?>, response: Response<Video?>) {
                 mostPopularVideoList.clear()
-                videos.items.forEach { item ->
+                response.body()?.items?.forEach { item ->
                     mostPopularVideoList.add(
                         MostPopularVideo(
                             item.id,
@@ -216,68 +250,18 @@ class HomeFragment : Fragment() {
                         )
                     )
                 }
-                _mostPopularVideos.value = mostPopularVideoList
+                clear1 = true
+                checkComplete()
             }
-        }
+
+            override fun onFailure(call: Call<Video?>, t: Throwable) {
+                TODO("Not yet implemented")
+            }
+
+        })
     }
 
     private fun communicateVideoByCategory(id: String) {
-        CoroutineScope(Dispatchers.Main).launch {
-            runCatching {
-                val videos = getVideoByCategory(id)
-                val channelIds = StringBuilder()
-                videoByCategoryList.clear()
-                channelByCategoryList.clear()
-                videos.items.forEach { item ->
-                    videoByCategoryList.add(
-                        CategoryVideo(
-                            item.id,
-                            item.snippet.publishedAt,
-                            item.snippet.channelTitle,
-                            item.snippet.title,
-                            item.snippet.description,
-                            item.snippet.thumbnails.medium.url,
-                            item.statistics.viewCount.toInt(),
-                            item.statistics.likeCount.toInt(),
-                            item.statistics.commentCount.toInt(),
-                            calRecommendScore(
-                                item.snippet.description,
-                                item.statistics.viewCount.toInt(),
-                                item.statistics.likeCount.toInt(),
-                                item.statistics.commentCount.toInt()
-                            )
-                        )
-                    )
-                    channelIds.append(item.snippet.channelID).append(",")
-                }
-
-                val channels = getChannelByCategory(channelIds.toString())
-                channels.items.forEach { item ->
-                    channelByCategoryList.add(
-                        CategoryChannel(
-                            item.id,
-                            item.snippet.title,
-                            item.snippet.thumbnails.medium.url
-                        )
-                    )
-                }
-
-                _videoByCategory.value = videoByCategoryList.sortedByDescending { it.recommendScore }
-                _channelByCategory.value = channelByCategoryList
-            }
-        }
-    }
-
-    private suspend fun getMostPopularVideos() = withContext(Dispatchers.IO) {
-        apiService.mostPopularVideos(
-            BuildConfig.YOUTUBE_API_KEY,
-            "snippet,statistics",
-            "mostPopular",
-            "kr"
-        )
-    }
-
-    private suspend fun getVideoByCategory(id: String) = withContext(Dispatchers.IO) {
         apiService.videoByCategory(
             BuildConfig.YOUTUBE_API_KEY,
             "snippet,statistics",
@@ -285,11 +269,54 @@ class HomeFragment : Fragment() {
             10,
             "kr",
             id
-        )
+        )?.enqueue(object : Callback<Video?> {
+            override fun onResponse(call: Call<Video?>, response: Response<Video?>) {
+                videoByCategoryList.clear()
+                channelIds.clear()
+                response.body()?.items?.forEach { item ->
+                    videoByCategoryList.add(
+                        HomeUiData.CategoryVideos(
+                            video = CategoryVideo(
+                                item.id,
+                                item.snippet.publishedAt,
+                                item.snippet.channelTitle,
+                                item.snippet.title,
+                                item.snippet.description,
+                                item.snippet.thumbnails.medium.url,
+                                item.statistics.viewCount.toInt(),
+                                item.statistics.likeCount.toInt(),
+                                item.statistics.commentCount.toInt(),
+                                calRecommendScore(
+                                    item.snippet.description,
+                                    item.statistics.viewCount.toInt(),
+                                    item.statistics.likeCount.toInt(),
+                                    item.statistics.commentCount.toInt()
+                                )
+                            )
+                        )
+                    )
+                    channelIds.append(item.snippet.channelID).append(",")
+                }
+
+                _clear2.value = true
+                checkComplete()
+            }
+
+            override fun onFailure(call: Call<Video?>, t: Throwable) {
+                Log.e("#heesoo", "onFailure: ${t.message}")
+            }
+        })
     }
 
-    private suspend fun getChannelByCategory(id: String) = withContext(Dispatchers.IO) {
-        apiService.channelByCategory(BuildConfig.YOUTUBE_API_KEY, "snippet,statistics", id)
+    private fun checkComplete() {
+        if (clear1 && clear2.value == true && clear3) {
+            homeAdapter.submitList(
+                list.apply {
+                    set(1, HomeUiData.MostPopularVideos(mostPopularVideoList))
+                    set(4, HomeUiData.CategoryChannels(channelByCategoryList))
+                } + videoByCategoryList
+            )
+        }
     }
 
     fun calRecommendScore(

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -8,102 +8,112 @@
     android:background="#1A1B1F"
     tools:context=".fragment.HomeFragment">
 
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_home"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+<!--    <ScrollView-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="match_parent">-->
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+<!--        <androidx.constraintlayout.widget.ConstraintLayout-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content">-->
 
-            <TextView
-                android:id="@+id/tv_home_most_popular_video"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="5dp"
-                android:text="가장 인기있는 영상"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+<!--            <TextView-->
+<!--                android:id="@+id/tv_home_most_popular_video"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_marginStart="5dp"-->
+<!--                android:text="가장 인기있는 영상"-->
+<!--                android:textSize="18sp"-->
+<!--                android:textStyle="bold"-->
+<!--                app:layout_constraintStart_toStartOf="parent"-->
+<!--                app:layout_constraintTop_toTopOf="parent" />-->
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/rv_home_most_popular_video"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="5dp"
-                android:orientation="horizontal"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintStart_toStartOf="@+id/tv_home_most_popular_video"
-                app:layout_constraintTop_toBottomOf="@+id/tv_home_most_popular_video" />
+<!--            <androidx.recyclerview.widget.RecyclerView-->
+<!--                android:id="@+id/rv_home_most_popular_video"-->
+<!--                android:layout_width="match_parent"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_marginTop="5dp"-->
+<!--                android:orientation="horizontal"-->
+<!--                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"-->
+<!--                app:layout_constraintStart_toStartOf="@+id/tv_home_most_popular_video"-->
+<!--                app:layout_constraintTop_toBottomOf="@+id/tv_home_most_popular_video" />-->
 
-            <Spinner
-                android:id="@+id/spinner_home_category"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:overlapAnchor="false"
-                android:background="@drawable/apply_spinner_background"
-                android:popupBackground="@color/black_background"
-                app:layout_constraintStart_toStartOf="@+id/rv_home_most_popular_video"
-                app:layout_constraintTop_toBottomOf="@+id/rv_home_most_popular_video" />
+<!--            <Spinner-->
+<!--                android:id="@+id/spinner_home_category"-->
+<!--                android:layout_width="match_parent"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_marginTop="10dp"-->
+<!--                android:overlapAnchor="false"-->
+<!--                android:background="@drawable/apply_spinner_background"-->
+<!--                android:popupBackground="@color/black_background"-->
+<!--                app:layout_constraintStart_toStartOf="@+id/rv_home_most_popular_video"-->
+<!--                app:layout_constraintTop_toBottomOf="@+id/rv_home_most_popular_video" />-->
 
-            <TextView
-                android:id="@+id/tv_home_category_channel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="채널"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                app:layout_constraintStart_toStartOf="@+id/spinner_home_category"
-                app:layout_constraintTop_toBottomOf="@+id/spinner_home_category" />
+<!--            <TextView-->
+<!--                android:id="@+id/tv_home_category_channel"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:text="채널"-->
+<!--                android:textSize="18sp"-->
+<!--                android:textStyle="bold"-->
+<!--                app:layout_constraintStart_toStartOf="@+id/spinner_home_category"-->
+<!--                app:layout_constraintTop_toBottomOf="@+id/spinner_home_category" />-->
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/rv_home_category_channel"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="5dp"
-                android:orientation="horizontal"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintStart_toStartOf="@+id/tv_home_most_popular_video"
-                app:layout_constraintTop_toBottomOf="@+id/tv_home_category_channel" />
+<!--            <androidx.recyclerview.widget.RecyclerView-->
+<!--                android:id="@+id/rv_home_category_channel"-->
+<!--                android:layout_width="match_parent"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_marginTop="5dp"-->
+<!--                android:orientation="horizontal"-->
+<!--                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"-->
+<!--                app:layout_constraintStart_toStartOf="@+id/tv_home_most_popular_video"-->
+<!--                app:layout_constraintTop_toBottomOf="@+id/tv_home_category_channel" />-->
 
-            <TextView
-                android:id="@+id/tv_home_category_video"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:text="영상"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                app:layout_constraintStart_toStartOf="@+id/spinner_home_category"
-                app:layout_constraintTop_toBottomOf="@+id/rv_home_category_channel" />
+<!--            <TextView-->
+<!--                android:id="@+id/tv_home_category_video"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_marginTop="10dp"-->
+<!--                android:text="영상"-->
+<!--                android:textSize="18sp"-->
+<!--                android:textStyle="bold"-->
+<!--                app:layout_constraintStart_toStartOf="@+id/spinner_home_category"-->
+<!--                app:layout_constraintTop_toBottomOf="@+id/rv_home_category_channel" />-->
 
-            <Spinner
-                android:id="@+id/spinner_home_sort_video"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@drawable/apply_spinner_background"
-                android:popupBackground="@color/black_background"
-                app:layout_constraintBottom_toBottomOf="@+id/tv_home_category_video"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/tv_home_category_video" />
+<!--            <Spinner-->
+<!--                android:id="@+id/spinner_home_sort_video"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:background="@drawable/apply_spinner_background"-->
+<!--                android:popupBackground="@color/black_background"-->
+<!--                app:layout_constraintBottom_toBottomOf="@+id/tv_home_category_video"-->
+<!--                app:layout_constraintEnd_toEndOf="parent"-->
+<!--                app:layout_constraintTop_toTopOf="@+id/tv_home_category_video" />-->
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/rv_home_category_video"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="5dp"
-                android:orientation="vertical"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_home_category_video" />
+<!--            <androidx.recyclerview.widget.RecyclerView-->
+<!--                android:id="@+id/rv_home_category_video"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_marginTop="5dp"-->
+<!--                android:orientation="vertical"-->
+<!--                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"-->
+<!--                app:layout_constraintEnd_toEndOf="parent"-->
+<!--                app:layout_constraintStart_toStartOf="parent"-->
+<!--                app:layout_constraintTop_toBottomOf="@+id/tv_home_category_video" />-->
 
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="80dp"
-                app:layout_constraintTop_toBottomOf="@+id/rv_home_category_video" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </ScrollView>
+<!--            <View-->
+<!--                android:layout_width="match_parent"-->
+<!--                android:layout_height="80dp"-->
+<!--                app:layout_constraintTop_toBottomOf="@+id/rv_home_category_video" />-->
+<!--        </androidx.constraintlayout.widget.ConstraintLayout>-->
+<!--    </ScrollView>-->
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_channel_by_category.xml
+++ b/app/src/main/res/layout/layout_channel_by_category.xml
@@ -21,6 +21,7 @@
         android:id="@+id/tv_channel_by_category_name"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
         android:layout_marginBottom="5dp"
         android:ellipsize="end"
         android:gravity="center"

--- a/app/src/main/res/layout/layout_most_popular_video.xml
+++ b/app/src/main/res/layout/layout_most_popular_video.xml
@@ -27,6 +27,7 @@
         android:id="@+id/tv_most_popular_video_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="3dp"
         android:layout_marginBottom="5dp"
         android:ellipsize="end"
         android:maxLines="1"

--- a/app/src/main/res/layout/layout_video_by_category_big.xml
+++ b/app/src/main/res/layout/layout_video_by_category_big.xml
@@ -78,7 +78,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="10dp"
-            android:layout_marginBottom="15dp"
+            android:layout_marginBottom="8dp"
             android:drawablePadding="6dp"
             android:gravity="center_vertical"
             android:text="평점"

--- a/app/src/main/res/layout/set_channel_by_category.xml
+++ b/app/src/main/res/layout/set_channel_by_category.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/black_background">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_home_category_channel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dp"
+        android:layout_marginTop="5dp"
+        android:orientation="horizontal"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/set_most_popular_video.xml
+++ b/app/src/main/res/layout/set_most_popular_video.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/black_background">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_home_most_popular_video"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/set_select_category.xml
+++ b/app/src/main/res/layout/set_select_category.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <Spinner
+        android:id="@+id/spinner_home_category"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/apply_spinner_background"
+        android:overlapAnchor="false"
+        android:popupBackground="@color/black_background"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/set_theme_title.xml
+++ b/app/src/main/res/layout/set_theme_title.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/black_background">
+
+    <TextView
+        android:id="@+id/tv_home_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="가장 인기있는 영상"
+        android:layout_marginStart="5dp"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/set_theme_title_with_spinner.xml
+++ b/app/src/main/res/layout/set_theme_title_with_spinner.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/black_background">
+
+    <TextView
+        android:id="@+id/tv_home_title2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="가장 인기있는 영상"
+        android:layout_marginStart="5dp"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Spinner
+    android:id="@+id/spinner_home_sort_video"
+    android:layout_width="120dp"
+    android:layout_height="wrap_content"
+    android:background="@drawable/apply_spinner_background"
+    android:popupBackground="@color/black_background"
+    app:layout_constraintBottom_toBottomOf="@+id/tv_home_title2"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintTop_toTopOf="@+id/tv_home_title2" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/set_video_by_category.xml
+++ b/app/src/main/res/layout/set_video_by_category.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/iv_thumbnail"
+        android:layout_width="380dp"
+        android:layout_height="240dp"
+        android:layout_marginVertical="8dp"
+        android:background="@drawable/apply_video_image_background"
+        android:clipToOutline="true"
+        android:scaleType="fitXY"
+        android:src="@drawable/galaxy"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/apply_video_title_background"
+        android:clipToOutline="true"
+        app:layout_constraintBottom_toBottomOf="@+id/iv_thumbnail"
+        app:layout_constraintEnd_toEndOf="@+id/iv_thumbnail"
+        app:layout_constraintStart_toStartOf="@+id/iv_thumbnail">
+
+        <TextView
+            android:id="@+id/tv_video_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="10dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="영상 이름"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toTopOf="@+id/tv_channel_name"
+            app:layout_constraintEnd_toStartOf="@+id/textView4"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_channel_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="5dp"
+            android:ellipsize="end"
+            android:gravity="bottom"
+            android:maxLines="1"
+            android:text="채널명"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/tv_upload_date"
+            app:layout_constraintStart_toStartOf="@+id/tv_video_title"
+            app:layout_constraintTop_toBottomOf="@+id/tv_video_title" />
+
+        <TextView
+            android:id="@+id/tv_upload_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:ellipsize="end"
+            android:gravity="center_vertical"
+            android:maxLines="1"
+            android:text="시간"
+            android:textSize="13sp"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_channel_name"
+            app:layout_constraintStart_toEndOf="@+id/tv_channel_name" />
+
+        <TextView
+            android:id="@+id/textView4"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="10dp"
+            android:layout_marginBottom="15dp"
+            android:drawablePadding="6dp"
+            android:gravity="center_vertical"
+            android:text="평점"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:drawableStartCompat="@drawable/apply_score_icon_resize"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [x] 버그픽스
- [x] 리팩토링
- [ ] 문서 변경
- [x] 레이아웃

## 변경사항 작성
변경사항의 상세 정보를 작성해주세요.

-기능
홈 프래그먼트 레이아웃 멀티뷰타입 리사이클러뷰로 변경
위의 변화로 인한 레이아웃 조정
유창님이 만드신 상세 페이지 데이터 이동 및 UI 출력 이식 완료
-설명
스크롤뷰 안에 리사이클러뷰 쓰는 건 좋지 않음을 알게 된 나는 멀티뷰타입 리사이클러뷰로 변경했다.
총 5개의 뷰타입으로 나누고 이를 Sealed Class로 나눠 순서에 맞게 어댑터에 넣어줬다.
스피너가 무한 반복되는 문제는 값을 저장해놨다가 사용하는 방식과 이전 선택값과 현재 선택값이 같을 때만 데이터를 불러오도록 하며 보완했다.
모든 데이터가 다 들어와야만 UI에 노출되도록 로직을 작성했다.
유창님이 다 만들어놓으신 거를 중간어댑터에 잘 이식시켜 동작하도록 했다.