### PR TITLE
[refactor] : home Fragment 데이터 받는 코드 변경, 화면 사용성 고려한 수정, MVVM 패턴 적용

### DIFF
--- a/app/src/main/java/com/example/meohaji/NetworkInterface.kt
+++ b/app/src/main/java/com/example/meohaji/NetworkInterface.kt
@@ -2,8 +2,8 @@ package com.example.meohaji
 
 import com.example.meohaji.home.Channel
 import com.example.meohaji.home.Video
-import retrofit2.Call
 import com.example.meohaji.search.SearchResult
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -11,29 +11,29 @@ import retrofit2.http.Query
 interface NetworkInterface {
 
     @GET("videos")
-    fun mostPopularVideos(
+    suspend fun mostPopularVideos(
         @Query("key") key: String?,
         @Query("part") part: String?,
         @Query("chart") chart: String?,
         @Query("regionCode") code: String?
-    ): Call<Video?>?
+    ): Response<Video>
 
     @GET("videos")
-    fun videoByCategory(
+    suspend fun videoByCategory(
         @Query("key") key: String?,
         @Query("part") part: String?,
         @Query("chart") chart: String?,
         @Query("maxResults") max: Int?,
         @Query("regionCode") code: String?,
         @Query("videoCategoryId") categoryId: String?,
-    ): Call<Video?>?
+    ): Response<Video>
 
     @GET("channels")
-    fun channelByCategory(
+    suspend fun channelByCategory(
         @Query("key") key: String?,
         @Query("part") part: String?,
         @Query("id") channelId: String?
-    ) : Call<Channel?>?
+    ) : Response<Channel>
 
     // q 타입 max 파트 오더 Regioncode
     @GET("search")

--- a/app/src/main/java/com/example/meohaji/home/HomeAdapter.kt
+++ b/app/src/main/java/com/example/meohaji/home/HomeAdapter.kt
@@ -30,7 +30,6 @@ class HomeAdapter(private val context: Context) :
         override fun areContentsTheSame(oldItem: HomeUiData, newItem: HomeUiData): Boolean {
             return oldItem == newItem
         }
-
     }) {
 
     interface CommunicateVideoByCategory {
@@ -129,9 +128,7 @@ class HomeAdapter(private val context: Context) :
             is HomeUiData.Title -> (holder as TitleViewHolder).bind(currentList[position] as HomeUiData.Title)
             is HomeUiData.CategoryChannels -> (holder as CategoryChannelViewHolder).bind(currentList[position] as HomeUiData.CategoryChannels)
             is HomeUiData.CategoryVideos -> (holder as CategoryVideoViewHolder).bind(currentList[position] as HomeUiData.CategoryVideos)
-            is HomeUiData.MostPopularVideos -> (holder as MostPopularVideoViewHolder).bind(
-                currentList[position] as HomeUiData.MostPopularVideos
-            )
+            is HomeUiData.MostPopularVideos -> (holder as MostPopularVideoViewHolder).bind(currentList[position] as HomeUiData.MostPopularVideos)
             is HomeUiData.Spinner -> (holder as SpinnerViewHolder).bind(currentList[position] as HomeUiData.Spinner)
             is HomeUiData.TitleWithSpinner -> (holder as TitleWithViewHolder).bind(currentList[position] as HomeUiData.TitleWithSpinner)
         }
@@ -148,18 +145,10 @@ class HomeAdapter(private val context: Context) :
         }
     }
 
-    companion object {
-        private const val CHANNEL = 1
-        private const val VIDEO = 2
-        private const val POPULARVIDEO = 3
-        private const val SPINNER = 4
-        private const val TITLE = 5
-        private const val TITLE_SPINNER = 6
-    }
-
     inner class CategoryChannelViewHolder(private val binding: LayoutChannelByCategoryBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(item: HomeUiData.CategoryChannels) {
+
             val categoryChannelAdapter = CategoryChannelAdapter(context)
             binding.rvHomeChannelByCategory.adapter = categoryChannelAdapter
             categoryChannelAdapter.submitList(item.list.toList())
@@ -169,6 +158,7 @@ class HomeAdapter(private val context: Context) :
     inner class CategoryVideoViewHolder(private val binding: ItemVideoByCategoryBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(item: HomeUiData.CategoryVideos) = with(binding) {
+
             Glide.with(context)
                 .load(item.video.thumbnail)
                 .into(ivVideoByCategoryItemThumbnail)
@@ -178,7 +168,7 @@ class HomeAdapter(private val context: Context) :
             tvVideoByCategoryItemUploadDate.text =
                 outputFormat.format(inputFormat.parse(item.video.publishedAt) as Date)
             tvVideoByCategoryItemRecommendScore.text = item.video.recommendScore.toString()
-            binding.ivVideoByCategoryItemThumbnail.setOnClickListener {
+            ivVideoByCategoryItemThumbnail.setOnClickListener {
                 detailCategoryVideo?.move(item.video)
             }
         }
@@ -187,8 +177,11 @@ class HomeAdapter(private val context: Context) :
     inner class MostPopularVideoViewHolder(private val binding: LayoutMostPopularVideoBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(item: HomeUiData.MostPopularVideos) {
+
             val mostPopularVideoAdapter = MostPopularVideoAdapter(context)
+
             binding.rvHomeMostPopularVideo.adapter = mostPopularVideoAdapter
+
             mostPopularVideoAdapter.submitList(item.list.toList())
             mostPopularVideoAdapter.videoClick =
                 object : MostPopularVideoAdapter.MostPopularVideoClick {
@@ -201,16 +194,17 @@ class HomeAdapter(private val context: Context) :
 
     inner class SpinnerViewHolder(private val binding: LayoutSelectCategoryBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(item: HomeUiData.Spinner) {
+        fun bind(item: HomeUiData.Spinner) = with(binding) {
+
             val adapter = ArrayAdapter(
                 context,
                 R.layout.support_simple_spinner_dropdown_item,
                 item.categories
             )
-            binding.spinnerHomeSelectCategory.adapter = adapter
 
-            binding.spinnerHomeSelectCategory.setSelection(categorySpinnerIdx)
-            binding.spinnerHomeSelectCategory.onItemSelectedListener =
+            spinnerHomeSelectCategory.adapter = adapter
+            spinnerHomeSelectCategory.setSelection(categorySpinnerIdx)
+            spinnerHomeSelectCategory.onItemSelectedListener =
                 object : AdapterView.OnItemSelectedListener {
                     override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
                         if (categorySpinnerIdx != p2) {
@@ -224,7 +218,6 @@ class HomeAdapter(private val context: Context) :
                     }
 
                     override fun onNothingSelected(p0: AdapterView<*>?) {
-                        TODO("Not yet implemented")
                     }
                 }
         }
@@ -233,24 +226,26 @@ class HomeAdapter(private val context: Context) :
     inner class TitleViewHolder(private val binding: LayoutThemeTitleBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(item: HomeUiData.Title) {
+
             binding.tvHomeThemeTitle.text = item.title
         }
     }
 
     inner class TitleWithViewHolder(private val binding: LayoutThemeTitleWithSpinnerBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(item: HomeUiData.TitleWithSpinner) {
-            binding.tvHomeThemeTitleWithSpinner.text = item.title
+        fun bind(item: HomeUiData.TitleWithSpinner) = with(binding){
+
+            tvHomeThemeTitleWithSpinner.text = item.title
 
             val adapter = ArrayAdapter(
                 context,
                 R.layout.support_simple_spinner_dropdown_item,
                 item.categories
             )
-            binding.spinnerHomeSortVideo.adapter = adapter
 
-            binding.spinnerHomeSortVideo.setSelection(sortSpinnerIdx)
-            binding.spinnerHomeSortVideo.onItemSelectedListener =
+            spinnerHomeSortVideo.adapter = adapter
+            spinnerHomeSortVideo.setSelection(sortSpinnerIdx)
+            spinnerHomeSortVideo.onItemSelectedListener =
                 object : AdapterView.OnItemSelectedListener {
                     override fun onItemSelected(p0: AdapterView<*>?, p1: View?, p2: Int, p3: Long) {
                         if (sortSpinnerIdx != p2) sortCategoryVideo?.sort(p2)
@@ -258,9 +253,17 @@ class HomeAdapter(private val context: Context) :
                     }
 
                     override fun onNothingSelected(p0: AdapterView<*>?) {
-                        TODO("Not yet implemented")
                     }
                 }
         }
+    }
+
+    companion object {
+        private const val CHANNEL = 1
+        private const val VIDEO = 2
+        private const val POPULARVIDEO = 3
+        private const val SPINNER = 4
+        private const val TITLE = 5
+        private const val TITLE_SPINNER = 6
     }
 }

--- a/app/src/main/java/com/example/meohaji/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/meohaji/home/HomeFragment.kt
@@ -3,25 +3,17 @@ package com.example.meohaji.home
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import com.example.meohaji.BuildConfig
-import com.example.meohaji.NetworkClient.apiService
+import androidx.fragment.app.viewModels
 import com.example.meohaji.databinding.FragmentHomeBinding
 import com.example.meohaji.detail.DetailFragment
 import com.example.meohaji.detail.DetailTags.DETAIL_CATEGORY
 import com.example.meohaji.detail.DetailTags.DETAIL_MOST
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
-import kotlin.math.round
 import android.os.Parcelable as Parcelable1
 
 class HomeFragment : Fragment() {
@@ -35,27 +27,7 @@ class HomeFragment : Fragment() {
         HomeAdapter(requireContext())
     }
 
-    private val mostPopularVideoList = arrayListOf<MostPopularVideo>()
-    private val videoByCategoryList = arrayListOf<CategoryVideo>()
-    private val channelByCategoryList = arrayListOf<CategoryChannel>()
-
-    private val list = arrayListOf(
-        HomeUiData.Title("지금 가장 인기있는 영상 TOP5"),
-        HomeUiData.MostPopularVideos(list = arrayListOf()),
-        HomeUiData.Spinner(YoutubeCategory.entries.map { it.str }),
-        HomeUiData.Title("해당 카테고리 채널"),
-        HomeUiData.CategoryChannels(list = arrayListOf()),
-        HomeUiData.TitleWithSpinner("카테고리 인기 영상", SortOrder.entries.map { it.str }),
-    )
-
-    private var _finishMostPopularVideoData = MutableLiveData<Boolean>()
-    private val finishMostPopularVideoData: LiveData<Boolean> get() = _finishMostPopularVideoData
-    private var _finishVideoByCategoryData = MutableLiveData<Boolean>()
-    private val finishVideoByCategoryData: LiveData<Boolean> get() = _finishVideoByCategoryData
-    private var _finishChannelByCategoryData = MutableLiveData<Boolean>()
-    private val finishChannelByCategoryData: LiveData<Boolean> get() = _finishChannelByCategoryData
-    val channelIds = StringBuilder()
-    private var sortOrderIdx = 0
+    private val homeViewModel: HomeViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -70,18 +42,18 @@ class HomeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initialCommunicateNetwork()
+        homeViewModel.initialCommunicateNetwork()
 
-//        communicateNetwork()
+        initViewModel()
+        initView()
+    }
 
+    private fun initView() {
         binding.rvHome.adapter = homeAdapter
         homeAdapter.apply {
             communicateVideoByCategory = object : HomeAdapter.CommunicateVideoByCategory {
                 override fun call(id: String, sortOrder: Int) {
-                    _finishVideoByCategoryData.value = false
-                    _finishChannelByCategoryData.value = false
-                    sortOrderIdx = sortOrder
-                    communicateVideoByCategory(id)
+                    homeViewModel.changeCategory(id, sortOrder)
                 }
             }
 
@@ -99,331 +71,22 @@ class HomeFragment : Fragment() {
 
             sortCategoryVideo = object : HomeAdapter.SortCategoryVideo {
                 override fun sort(order: Int) {
-                    sortByOrder(order)
-                    checkComplete(1)
+                    homeViewModel.sortVideo(order)
                 }
             }
         }
+    }
 
-        finishMostPopularVideoData.observe(viewLifecycleOwner) {
-            if (it) checkComplete(0)
-        }
-
-        finishChannelByCategoryData.observe(viewLifecycleOwner) {
-            if (it) checkComplete(0)
-        }
-
-        finishVideoByCategoryData.observe(viewLifecycleOwner) {
-            if (it) {
-                apiService.channelByCategory(
-                    BuildConfig.YOUTUBE_API_KEY,
-                    "snippet,statistics",
-                    channelIds.toString()
-                )?.enqueue(object : Callback<Channel?> {
-                    override fun onResponse(
-                        call: Call<Channel?>,
-                        response: Response<Channel?>
-                    ) {
-                        channelByCategoryList.clear()
-                        response.body()?.items?.forEach { item ->
-                            channelByCategoryList.add(
-                                CategoryChannel(
-                                    item.id,
-                                    item.snippet.title,
-                                    item.snippet.thumbnails.medium.url
-                                )
-                            )
-                        }
-
-                        _finishChannelByCategoryData.value = true
-                    }
-
-                    override fun onFailure(call: Call<Channel?>, t: Throwable) {
-                        Log.e("#heesoo", "onFailure: ${t.message}")
-                    }
-                })
-            }
+    private fun initViewModel() = with(homeViewModel) {
+        homeList.observe(viewLifecycleOwner) {
+            homeAdapter.submitList(it.toList())
         }
     }
 
-    private fun sortByOrder(order: Int) {
-        when (order) {
-            0 -> {
-                videoByCategoryList.sortByDescending { it.recommendScore }
-            }
-
-            1 -> {
-                videoByCategoryList.sortByDescending { it.viewCount }
-            }
-
-            2 -> {
-                videoByCategoryList.sortByDescending { it.likeCount }
-            }
-
-            3 -> {
-                videoByCategoryList.sortByDescending { it.publishedAt }
-            }
-        }
-    }
-
-    private fun initialCommunicateNetwork() {
-        _finishMostPopularVideoData.value = false
-        _finishVideoByCategoryData.value = false
-        _finishChannelByCategoryData.value = false
-
-        communicateMostPopularVideos()
-        communicateVideoByCategory("1")
-    }
-
-//    private fun communicateNetwork() {
-//        CoroutineScope(Dispatchers.Default).launch {
-//            async(Dispatchers.IO) {
-//                apiService.mostPopularVideos(
-//                    BuildConfig.YOUTUBE_API_KEY,
-//                    "snippet,statistics",
-//                    "mostPopular",
-//                    "kr"
-//                )?.enqueue(object : Callback<Video?> {
-//                    override fun onResponse(call: Call<Video?>, response: Response<Video?>) {
-//                        mostPopularVideoList.clear()
-//                        response.body()?.items?.forEach { item ->
-//                            mostPopularVideoList.add(
-//                                MostPopularVideo(
-//                                    item.id,
-//                                    item.snippet.publishedAt,
-//                                    item.snippet.channelTitle,
-//                                    item.snippet.title,
-//                                    item.snippet.description,
-//                                    item.snippet.thumbnails.medium.url,
-//                                    item.statistics.viewCount.toInt(),
-//                                    item.statistics.likeCount.toInt(),
-//                                    item.statistics.commentCount.toInt(),
-//                                    calRecommendScore(
-//                                        item.snippet.description,
-//                                        item.statistics.viewCount.toInt(),
-//                                        item.statistics.likeCount.toInt(),
-//                                        item.statistics.commentCount.toInt()
-//                                    )
-//                                )
-//                            )
-//                        }
-//                    }
-//
-//                    override fun onFailure(call: Call<Video?>, t: Throwable) {
-//                        TODO("Not yet implemented")
-//                    }
-//
-//                })
-//            }.await()
-//
-//            async(Dispatchers.IO) {
-//                apiService.videoByCategory(
-//                    BuildConfig.YOUTUBE_API_KEY,
-//                    "snippet,statistics",
-//                    "mostPopular",
-//                    10,
-//                    "kr",
-//                    YoutubeCategory.entries[0].id
-//                )?.enqueue(object : Callback<Video?> {
-//                    override fun onResponse(call: Call<Video?>, response: Response<Video?>) {
-//                        videoByCategoryList.clear()
-//                        channelIds.clear()
-//                        response.body()?.items?.forEach { item ->
-//                            videoByCategoryList.add(
-//                                CategoryVideo(
-//                                    item.id,
-//                                    item.snippet.publishedAt,
-//                                    item.snippet.channelTitle,
-//                                    item.snippet.title,
-//                                    item.snippet.description,
-//                                    item.snippet.thumbnails.medium.url,
-//                                    item.statistics.viewCount.toInt(),
-//                                    item.statistics.likeCount.toInt(),
-//                                    item.statistics.commentCount.toInt(),
-//                                    calRecommendScore(
-//                                        item.snippet.description,
-//                                        item.statistics.viewCount.toInt(),
-//                                        item.statistics.likeCount.toInt(),
-//                                        item.statistics.commentCount.toInt()
-//                                    )
-//                                )
-//                            )
-//                            channelIds.append(item.snippet.channelID).append(",")
-//                        }
-//
-//                        videoByCategoryList.sortByDescending { it.recommendScore }
-//                    }
-//
-//                    override fun onFailure(call: Call<Video?>, t: Throwable) {
-//                        Log.e("#heesoo", "onFailure: ${t.message}")
-//                    }
-//                })
-//            }.await()
-//
-//            async(Dispatchers.IO) {
-//                apiService.channelByCategory(
-//                    BuildConfig.YOUTUBE_API_KEY,
-//                    "snippet,statistics",
-//                    channelIds.toString()
-//                )?.enqueue(object : Callback<Channel?> {
-//                    override fun onResponse(
-//                        call: Call<Channel?>,
-//                        response: Response<Channel?>
-//                    ) {
-//                        channelByCategoryList.clear()
-//                        response.body()?.items?.forEach { item ->
-//                            channelByCategoryList.add(
-//                                CategoryChannel(
-//                                    item.id,
-//                                    item.snippet.title,
-//                                    item.snippet.thumbnails.medium.url
-//                                )
-//                            )
-//                        }
-//                    }
-//
-//                    override fun onFailure(call: Call<Channel?>, t: Throwable) {
-//                        Log.e("#heesoo", "onFailure: ${t.message}")
-//                    }
-//                })
-//            }.await()
-//
-//            withContext(Dispatchers.Main) {
-//                checkComplete(0)
-//            }
-//        }
-//    }
 
     override fun onDestroyView() {
         _binding = null
         super.onDestroyView()
-    }
-
-    private fun communicateMostPopularVideos() {
-        apiService.mostPopularVideos(
-            BuildConfig.YOUTUBE_API_KEY,
-            "snippet,statistics",
-            "mostPopular",
-            "kr"
-        )?.enqueue(object : Callback<Video?> {
-            override fun onResponse(call: Call<Video?>, response: Response<Video?>) {
-                mostPopularVideoList.clear()
-                response.body()?.items?.forEach { item ->
-                    mostPopularVideoList.add(
-                        MostPopularVideo(
-                            item.id,
-                            item.snippet.publishedAt,
-                            item.snippet.channelTitle,
-                            item.snippet.title,
-                            item.snippet.description,
-                            item.snippet.thumbnails.medium.url,
-                            item.statistics.viewCount.toInt(),
-                            item.statistics.likeCount.toInt(),
-                            item.statistics.commentCount.toInt(),
-                            calRecommendScore(
-                                item.snippet.description,
-                                item.statistics.viewCount.toInt(),
-                                item.statistics.likeCount.toInt(),
-                                item.statistics.commentCount.toInt()
-                            )
-                        )
-                    )
-                }
-                _finishMostPopularVideoData.value = true
-            }
-
-            override fun onFailure(call: Call<Video?>, t: Throwable) {
-                Log.e("#heesoo", "onFailure: ${t.message}")
-            }
-
-        })
-    }
-
-    private fun communicateVideoByCategory(id: String) {
-        apiService.videoByCategory(
-            BuildConfig.YOUTUBE_API_KEY,
-            "snippet,statistics",
-            "mostPopular",
-            10,
-            "kr",
-            id
-        )?.enqueue(object : Callback<Video?> {
-            override fun onResponse(call: Call<Video?>, response: Response<Video?>) {
-                videoByCategoryList.clear()
-                channelIds.clear()
-                response.body()?.items?.forEach { item ->
-                    videoByCategoryList.add(
-                        CategoryVideo(
-                            item.id,
-                            item.snippet.publishedAt,
-                            item.snippet.channelTitle,
-                            item.snippet.title,
-                            item.snippet.description,
-                            item.snippet.thumbnails.medium.url,
-                            item.statistics.viewCount.toInt(),
-                            item.statistics.likeCount.toInt(),
-                            item.statistics.commentCount.toInt(),
-                            calRecommendScore(
-                                item.snippet.description,
-                                item.statistics.viewCount.toInt(),
-                                item.statistics.likeCount.toInt(),
-                                item.statistics.commentCount.toInt()
-                            )
-                        )
-                    )
-                    channelIds.append(item.snippet.channelID).append(",")
-                }
-
-                sortByOrder(sortOrderIdx)
-                _finishVideoByCategoryData.value = true
-            }
-
-            override fun onFailure(call: Call<Video?>, t: Throwable) {
-                Log.e("#heesoo", "onFailure: ${t.message}")
-            }
-        })
-    }
-
-    private fun checkComplete(type: Int) {
-        if (finishMostPopularVideoData.value == true && finishVideoByCategoryData.value == true && finishChannelByCategoryData.value == true) {
-            when (type) {
-                0 -> {
-                    homeAdapter.submitList(
-                        list.apply {
-                            set(1, HomeUiData.MostPopularVideos(mostPopularVideoList))
-                            set(4, HomeUiData.CategoryChannels(channelByCategoryList))
-                        } + videoByCategoryList.map {
-                            HomeUiData.CategoryVideos(it)
-                        }
-                    )
-                }
-
-                1 -> {
-                    homeAdapter.submitList(
-                        list + videoByCategoryList.map {
-                            HomeUiData.CategoryVideos(it)
-                        }
-                    )
-                }
-            }
-        }
-    }
-
-    fun calRecommendScore(
-        description: String,
-        viewCount: Int,
-        likeCount: Int,
-        commentCount: Int
-    ): Double {
-        val viewScore = viewCount * 0.5 * (1.0 / viewCount.toString().length)
-        val likeScore = likeCount * 0.3 * (1.0 / likeCount.toString().length)
-        val commentScore = commentCount * 0.2 * (1.0 / commentCount.toString().length)
-        val isShorts = description.contains("shorts")
-
-        var totalScore =
-            if (isShorts) (viewScore + likeScore + commentScore) / viewScore * 3.3 * 1.5 else (viewScore + likeScore + commentScore) / viewScore * 3.3
-        totalScore = round(totalScore * 10) / 10
-        return if (totalScore > 5.0) 5.0 else totalScore
     }
 
     private fun overrideBackAction() {

--- a/app/src/main/java/com/example/meohaji/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/meohaji/home/HomeViewModel.kt
@@ -1,0 +1,222 @@
+package com.example.meohaji.home
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.meohaji.BuildConfig
+import com.example.meohaji.NetworkClient
+import kotlinx.coroutines.launch
+import kotlin.math.round
+
+class HomeViewModel : ViewModel() {
+
+    private val _homeList = MutableLiveData(
+        listOf(
+            HomeUiData.Title("지금 가장 인기있는 영상 TOP5"),
+            HomeUiData.MostPopularVideos(list = listOf()),
+            HomeUiData.Spinner(YoutubeCategory.entries.map { it.str }),
+            HomeUiData.Title("해당 카테고리 채널"),
+            HomeUiData.CategoryChannels(list = listOf()),
+            HomeUiData.TitleWithSpinner("카테고리 인기 영상", SortOrder.entries.map { it.str }),
+        )
+    )
+    val homeList: LiveData<List<HomeUiData>> get() = _homeList
+
+    private val mostPopularVideoList = arrayListOf<MostPopularVideo>()
+    private val videoByCategoryList = arrayListOf<CategoryVideo>()
+    private val channelByCategoryList = arrayListOf<CategoryChannel>()
+
+    private val channelIds = StringBuilder()
+    private var sortOrderIdx = 0
+
+    fun initialCommunicateNetwork() {
+        viewModelScope.launch {
+            communicateMostPopularVideos()
+            communicateVideoByCategory("1")
+            checkComplete(ENTIRE_CHANGE)
+        }
+    }
+
+    fun changeCategory(id: String, sortOrder: Int) {
+        viewModelScope.launch {
+            sortOrderIdx = sortOrder
+            communicateVideoByCategory(id)
+            checkComplete(CATEGORY_CHANGE)
+        }
+    }
+
+    fun sortVideo(sortOrder: Int) {
+        sortByOrder(sortOrder)
+        checkComplete(SORT_CHANGE)
+    }
+
+    private suspend fun communicateMostPopularVideos() {
+            val response = NetworkClient.apiService.mostPopularVideos(
+                BuildConfig.YOUTUBE_API_KEY,
+                "snippet,statistics",
+                "mostPopular",
+                "kr"
+            )
+            if (response.isSuccessful) {
+                mostPopularVideoList.clear()
+                response.body()?.items?.forEach { item ->
+                    mostPopularVideoList.add(
+                        MostPopularVideo(
+                            item.id,
+                            item.snippet.publishedAt,
+                            item.snippet.channelTitle,
+                            item.snippet.title,
+                            item.snippet.description,
+                            item.snippet.thumbnails.medium.url,
+                            item.statistics.viewCount.toInt(),
+                            item.statistics.likeCount.toInt(),
+                            item.statistics.commentCount.toInt(),
+                            calRecommendScore(
+                                item.snippet.description,
+                                item.statistics.viewCount.toInt(),
+                                item.statistics.likeCount.toInt(),
+                                item.statistics.commentCount.toInt()
+                            )
+                        )
+                    )
+                }
+            } else {
+                Log.d("dkj", "is not Successful")
+            }
+
+    }
+
+    private suspend fun communicateVideoByCategory(id: String) {
+            val response = NetworkClient.apiService.videoByCategory(
+                BuildConfig.YOUTUBE_API_KEY,
+                "snippet,statistics",
+                "mostPopular",
+                10,
+                "kr",
+                id
+            )
+            if (response.isSuccessful) {
+                videoByCategoryList.clear()
+                channelIds.clear()
+                response.body()?.items?.forEach { item ->
+                    videoByCategoryList.add(
+                        CategoryVideo(
+                            item.id,
+                            item.snippet.publishedAt,
+                            item.snippet.channelTitle,
+                            item.snippet.title,
+                            item.snippet.description,
+                            item.snippet.thumbnails.medium.url,
+                            item.statistics.viewCount.toInt(),
+                            item.statistics.likeCount.toInt(),
+                            item.statistics.commentCount.toInt(),
+                            calRecommendScore(
+                                item.snippet.description,
+                                item.statistics.viewCount.toInt(),
+                                item.statistics.likeCount.toInt(),
+                                item.statistics.commentCount.toInt()
+                            )
+                        )
+                    )
+                    channelIds.append(item.snippet.channelID).append(",")
+                }
+                sortByOrder(sortOrderIdx)
+
+                communicationChannelByCategory()
+            }
+
+    }
+
+    private suspend fun communicationChannelByCategory() {
+            val response = NetworkClient.apiService.channelByCategory(
+                BuildConfig.YOUTUBE_API_KEY,
+                "snippet,statistics",
+                channelIds.toString()
+            )
+            if (response.isSuccessful) {
+                channelByCategoryList.clear()
+                response.body()?.items?.forEach { item ->
+                    channelByCategoryList.add(
+                        CategoryChannel(
+                            item.id,
+                            item.snippet.title,
+                            item.snippet.thumbnails.medium.url
+                        )
+                    )
+                }
+            }
+
+    }
+
+    private fun calRecommendScore(
+        description: String,
+        viewCount: Int,
+        likeCount: Int,
+        commentCount: Int
+    ): Double {
+        val viewScore = viewCount * 0.5 * (1.0 / viewCount.toString().length)
+        val likeScore = likeCount * 0.3 * (1.0 / likeCount.toString().length)
+        val commentScore = commentCount * 0.2 * (1.0 / commentCount.toString().length)
+        val isShorts = description.contains("shorts")
+
+        var totalScore =
+            if (isShorts) (viewScore + likeScore + commentScore) / viewScore * 3.3 * 1.5 else (viewScore + likeScore + commentScore) / viewScore * 3.3
+        totalScore = round(totalScore * 10) / 10
+        return if (totalScore > 5.0) 5.0 else totalScore
+    }
+
+    private fun sortByOrder(order: Int) {
+        when (order) {
+            0 -> {
+                videoByCategoryList.sortByDescending { it.recommendScore }
+            }
+
+            1 -> {
+                videoByCategoryList.sortByDescending { it.viewCount }
+            }
+
+            2 -> {
+                videoByCategoryList.sortByDescending { it.likeCount }
+            }
+
+            3 -> {
+                videoByCategoryList.sortByDescending { it.publishedAt }
+            }
+        }
+    }
+
+    private fun checkComplete(type: Int) {
+        when (type) {
+            0 -> {
+                _homeList.value = homeList.value.orEmpty().toMutableList().subList(0, 6).apply {
+                    set(1, HomeUiData.MostPopularVideos(mostPopularVideoList))
+                    set(4, HomeUiData.CategoryChannels(channelByCategoryList))
+                } + videoByCategoryList.map {
+                    HomeUiData.CategoryVideos(it)
+                }
+            }
+
+            1 -> {
+                _homeList.value = homeList.value.orEmpty().toMutableList().subList(0, 6).apply {
+                    set(4, HomeUiData.CategoryChannels(channelByCategoryList))
+                } + videoByCategoryList.map {
+                    HomeUiData.CategoryVideos(it)
+                }
+            }
+
+            2 -> {
+                _homeList.value = homeList.value.orEmpty().toMutableList().subList(0, 6) + videoByCategoryList.map {
+                    HomeUiData.CategoryVideos(it)
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val ENTIRE_CHANGE = 0
+        const val CATEGORY_CHANGE = 1
+        const val SORT_CHANGE = 2
+    }
+}


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [ ] 버그픽스
- [x] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃

## 변경사항 작성
변경사항의 상세 정보를 작성해주세요.

-기능
1. API를 이용하여 데이터 받아오는 걸 코루틴을 사용하는 방식으로 변경
2. 화면에 새로 불러와져야하는 부분만 작동하도록 상수값을 만들고 조건을 나눔
3. Home 프래그먼트 MVVM 패턴으로 변경
-설명
1. 코루틴 사용 성공… 
 1) 가장 먼저 API 인터페이스 만들 때 suspend 붙이고 Response 타입으로 받도록 수정
 2) 사용하는 함수에서도 suspend fun으로 만듬
 3) viewModelScope.launch로 감쌈(뷰모델을 만들었기 때문에 viewModelScope이다.)
 4) 인터페이스 결과를 response로 받고 isSuccessful일때 이 후 작업을 실행시킴
 5) 채널같은 경우에는 비디오의 채널 아이디가 필요했기 때문에 비디오 결과를 다 받아오고 나서 이어서 실행시킴
 6) viewModelScope.launch 안에 있는 suspend 함수들은 각각이 끝나야지 다음으로 넘어가는 순차적인 진행을 한다.
 7) 이제 받아온 값들을 잘 가공하여 homeList 라이브 데이터의 값을 변경한다.
2. 리사이클러뷰 submitList를 케이스에 맞춰 다르게 하도록 전체 변경, 카테고리 변경, 정렬 변경에 대한 상수값들을 추가함
3. 가장 중요한 데이터 받고 출력하는 부분은 다 넘겼는데 다이얼로그 프래그먼트 부르는 부분은 아직 못 함