### PR TITLE
[refactor] : 마이 페이지 구성 멀티 뷰타입 리사이클러뷰로 변경

### DIFF
--- a/app/src/main/java/com/example/meohaji/mypage/MyPageAdapter.kt
+++ b/app/src/main/java/com/example/meohaji/mypage/MyPageAdapter.kt
@@ -1,55 +1,170 @@
 package com.example.meohaji.mypage
 
 import android.content.Context
+import android.graphics.drawable.Drawable
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.example.meohaji.R
+import com.example.meohaji.Utils
 import com.example.meohaji.databinding.ItemVideoByCategoryBinding
+import com.example.meohaji.databinding.LayoutMyProfileBinding
+import com.example.meohaji.databinding.LayoutSaveVideoTitleBinding
 import com.example.meohaji.home.VideoForUi
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 
-class MyPageAdapter(private val context: Context) : ListAdapter<VideoForUi, MyPageAdapter.Holder>(
-    object : DiffUtil.ItemCallback<VideoForUi>() {
-        override fun areItemsTheSame(oldItem: VideoForUi, newItem: VideoForUi): Boolean {
-            return oldItem.id == newItem.id
+class MyPageAdapter(private val context: Context) :
+    ListAdapter<MyPageUiData, RecyclerView.ViewHolder>(
+        object : DiffUtil.ItemCallback<MyPageUiData>() {
+            override fun areItemsTheSame(oldItem: MyPageUiData, newItem: MyPageUiData): Boolean {
+                return oldItem === newItem
+            }
+
+            override fun areContentsTheSame(oldItem: MyPageUiData, newItem: MyPageUiData): Boolean {
+                return oldItem == newItem
+            }
         }
+    ) {
 
-        override fun areContentsTheSame(oldItem: VideoForUi, newItem: VideoForUi): Boolean {
-            return oldItem == newItem
-        }
+    interface EditMyProfile {
+        fun open(name: String, image: Drawable?)
     }
-) {
 
-    inner class Holder(private val binding: ItemVideoByCategoryBinding) :
-        RecyclerView.ViewHolder(binding.root) {
-        fun bind(item: VideoForUi) = with(binding) {
-            Glide.with(context)
-                .load(item.thumbnail)
-                .into(ivVideoByCategoryItemThumbnail)
-
-            tvVideoByCategoryItemTitle.text = item.title
-            tvVideoByCategoryItemChannelName.text = item.likeCount.toString()
-            tvVideoByCategoryItemUploadDate.text = item.viewCount.toString()
-            tvVideoByCategoryItemRecommendScore.text = item.recommendScore.toString()
-        }
-
+    interface DetailSaveVideo {
+        fun move(videoData: VideoForUi)
     }
+
+    var editMyProfile: EditMyProfile? = null
+    var detailSaveVideo: DetailSaveVideo? = null
+
+    val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX", Locale.getDefault())
+    val outputFormat = SimpleDateFormat("yyyy.MM.dd HH:mm", Locale.getDefault())
 
     override fun getItemCount(): Int {
         return currentList.size
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
-        val binding = ItemVideoByCategoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return Holder(binding)
+    override fun getItemViewType(position: Int): Int {
+        return when (currentList[position]) {
+            is MyPageUiData.Profile -> PROFILE
+            is MyPageUiData.Title -> TITLE
+            is MyPageUiData.Video -> VIDEO
+        }
     }
 
-    override fun onBindViewHolder(holder: Holder, position: Int) {
-        holder.bind(currentList[position])
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            PROFILE -> {
+                ProfileViewHolder(
+                    LayoutMyProfileBinding.inflate(
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
+                )
+            }
+
+            TITLE -> {
+                TitleViewHolder(
+                    LayoutSaveVideoTitleBinding.inflate(
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
+                )
+            }
+
+            else -> {
+                SaveVideoViewHolder(
+                    ItemVideoByCategoryBinding.inflate(
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
+                )
+            }
+        }
     }
 
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (currentList[position]) {
+            is MyPageUiData.Profile -> (holder as ProfileViewHolder).bind(currentList[position] as MyPageUiData.Profile)
+            is MyPageUiData.Title -> (holder as TitleViewHolder).bind(currentList[position] as MyPageUiData.Title)
+            is MyPageUiData.Video -> (holder as SaveVideoViewHolder).bind(currentList[position] as MyPageUiData.Video)
+        }
+    }
+
+    inner class ProfileViewHolder(private val binding: LayoutMyProfileBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: MyPageUiData.Profile) = with(binding) {
+            tvMyPageName.text = item.name
+            Glide.with(context)
+                .load(item.image)
+                .into(civMyPageProfile)
+
+            btnMyPageEditName.setOnClickListener {
+                editMyProfile?.open(
+                    tvMyPageName.text.toString(),
+                    if (civMyPageProfile.drawable == null) null else civMyPageProfile.drawable
+                )
+            }
+        }
+    }
+
+    inner class TitleViewHolder(private val binding: LayoutSaveVideoTitleBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: MyPageUiData.Title) = with(binding) {
+            val spannableString = SpannableString(tvMyPageSavedVideo.text)
+            spannableString.setSpan(
+                ForegroundColorSpan(
+                    ContextCompat.getColor(
+                        context,
+                        R.color.yellow_background
+                    )
+                ),
+                0, 2, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+            tvMyPageSavedVideo.text = spannableString
+
+            btnClearSavedVideo.setOnClickListener {
+                Utils.deletePrefItem(context)
+                submitList(currentList.subList(0, 2))
+            }
+        }
+    }
+
+    inner class SaveVideoViewHolder(private val binding: ItemVideoByCategoryBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: MyPageUiData.Video) = with(binding) {
+            Glide.with(context)
+                .load(item.video.thumbnail)
+                .into(ivVideoByCategoryItemThumbnail)
+
+            tvVideoByCategoryItemTitle.text = item.video.title
+            tvVideoByCategoryItemChannelName.text = item.video.channelTitle
+            tvVideoByCategoryItemUploadDate.text =
+                outputFormat.format(inputFormat.parse(item.video.publishedAt) as Date)
+            tvVideoByCategoryItemRecommendScore.text = item.video.recommendScore.toString()
+            ivVideoByCategoryItemThumbnail.setOnClickListener {
+                detailSaveVideo?.move(item.video)
+            }
+        }
+    }
+
+    companion object {
+        private const val PROFILE = 1
+        private const val TITLE = 2
+        private const val VIDEO = 3
+    }
 }
 

--- a/app/src/main/java/com/example/meohaji/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/example/meohaji/mypage/MyPageFragment.kt
@@ -3,13 +3,11 @@ package com.example.meohaji.mypage
 import android.app.AlertDialog
 import android.content.Context
 import android.content.SharedPreferences
+import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.text.Spannable
-import android.text.SpannableString
-import android.text.style.ForegroundColorSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -23,23 +21,26 @@ import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.bumptech.glide.Glide
 import com.example.meohaji.R
 import com.example.meohaji.Utils
 import com.example.meohaji.databinding.FragmentMyPageBinding
+import com.example.meohaji.detail.BtnClick
+import com.example.meohaji.detail.DetailFragment
 import com.example.meohaji.detail.DetailTags
 import com.example.meohaji.home.VideoForUi
 import com.google.gson.GsonBuilder
 
 
 class MyPageFragment : Fragment() {
-    private lateinit var binding: FragmentMyPageBinding
+    private var _binding: FragmentMyPageBinding? = null
+    private val binding get() = _binding!!
     private var backPressedOnce = false
     private var selectedImageUri: Uri? = null
     private lateinit var dialogImg: ImageView
     private lateinit var myPageAdapter: MyPageAdapter
     private var items: ArrayList<VideoForUi> = ArrayList()
     private lateinit var preferences: SharedPreferences
+    var uiData: List<MyPageUiData> = listOf()
 
     private val pickImageFromGallery =
         registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
@@ -53,7 +54,7 @@ class MyPageFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentMyPageBinding.inflate(inflater, container, false)
+        _binding = FragmentMyPageBinding.inflate(inflater, container, false)
         overrideBackAction()
 
         preferences = requireContext().getSharedPreferences(
@@ -61,82 +62,66 @@ class MyPageFragment : Fragment() {
             Context.MODE_PRIVATE
         )
 
-        val textView = binding.tvMyPageSavedVideo
-        val spannableString = SpannableString(textView.text)
-        spannableString.setSpan(
-            ForegroundColorSpan(
-                ContextCompat.getColor(
-                    requireContext(),
-                    R.color.yellow_background
-                )
-            ),
-            0, 2, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-        )
-        textView.text = spannableString
-
-        val (name, image) = Utils.getMyInfo(requireContext())
-        binding.tvMyPageName.text = name
-        Glide.with(requireContext())
-            .load(image?.toUri())
-            .into(binding.civMyPageProfile)
-
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val (name, image) = Utils.getMyInfo(requireContext())
         items = loadData()
+        selectedImageUri = image?.toUri()
+        uiData = listOf(
+            MyPageUiData.Profile(name, image),
+            MyPageUiData.Title,
+        ) + items.map { MyPageUiData.Video(it) }
+
         myPageAdapter = MyPageAdapter(requireContext())
-        myPageAdapter.submitList(items.toList())
-        val recyclerView = binding.rvMyPage
-        recyclerView.adapter = myPageAdapter
-        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        myPageAdapter.apply {
+            editMyProfile = object : MyPageAdapter.EditMyProfile {
+                override fun open(name: String, image: Drawable?) {
+                    val dialogView =
+                        LayoutInflater.from(requireContext()).inflate(R.layout.dialog_mydata, null)
+                    dialogImg = dialogView.findViewById(R.id.civ_dialog_profile)
+                    val dialogName = dialogView.findViewById<EditText>(R.id.et_dialog_name)
+                    val changeBtn = dialogView.findViewById<Button>(R.id.btn_dialog_change)
+                    val builder = AlertDialog.Builder(context)
+                    builder.setView(dialogView)
+                    builder.setPositiveButton("확인") { dialog, _ ->
+                        uiData = listOf(MyPageUiData.Profile(dialogName.text.toString(), selectedImageUri.toString())) + uiData.subList(1, uiData.size)
+                        myPageAdapter.submitList(uiData.toList())
+                        Utils.saveMaInfo(
+                            requireContext(),
+                            dialogName.text.toString(),
+                            selectedImageUri.toString()
+                        )
+                        dialog.dismiss()
+                    }
+                    builder.setNegativeButton("취소") { dialog, _ ->
+                        dialog.cancel()
+                    }
+                    val dialog = builder.create()
+                    dialog.window?.setBackgroundDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.apply_corner_radius_10))
+                    dialog.show()
+                    dialogName.setText(name)
+                    dialogImg.setImageDrawable(image)
 
-
-        binding.btnMyPageEditName.setOnClickListener {
-            val dialogView =
-                LayoutInflater.from(requireContext()).inflate(R.layout.dialog_mydata, null)
-            dialogImg = dialogView.findViewById(R.id.civ_dialog_profile)
-            val dialogName = dialogView.findViewById<EditText>(R.id.et_dialog_name)
-            val changeBtn = dialogView.findViewById<Button>(R.id.btn_dialog_change)
-
-            val builder = AlertDialog.Builder(context)
-            builder.setView(dialogView)
-            builder.setPositiveButton("확인") { dialog, _ ->
-                binding.tvMyPageName.text = dialogName.text
-                binding.civMyPageProfile.setImageURI(selectedImageUri)
-                Utils.saveMaInfo(
-                    requireContext(),
-                    dialogName.text.toString(),
-                    selectedImageUri.toString()
-                )
-                dialog.dismiss()
+                    changeBtn.setOnClickListener {
+                        pickImageFromGallery.launch("image/*")
+                    }
+                }
             }
-            builder.setNegativeButton("취소") { dialog, _ ->
-                dialog.cancel()
-            }
 
-            val dialog = builder.create()
-            dialog.window?.setBackgroundDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.apply_corner_radius_10))
-            dialog.show()
-            dialogName.setText(binding.tvMyPageName.text)
-            dialogImg.setImageDrawable(binding.civMyPageProfile.drawable)
-
-            changeBtn.setOnClickListener {
-                pickImageFromGallery.launch("image/*")
+            detailSaveVideo = object : MyPageAdapter.DetailSaveVideo {
+                override fun move(videoData: VideoForUi) {
+                    setDetailFragment(videoData)
+                }
             }
         }
 
-        binding.btnClearSavedVideo.setOnClickListener {
-            Utils.deletePrefItem(requireContext())
-            items.clear() // 저장된 아이템 리스트를 비웁니다.
-            myPageAdapter.submitList(items.toList())
-        }
-        binding.btnRefreshSavedVideo.setOnClickListener {
-            items = loadData()
-            myPageAdapter.submitList(items.toList())
-        }
+        binding.rvMyPage.adapter = myPageAdapter
+        binding.rvMyPage.layoutManager = LinearLayoutManager(requireContext())
+        myPageAdapter.submitList(uiData.toList())
     }
 
     private fun overrideBackAction() {
@@ -156,7 +141,8 @@ class MyPageFragment : Fragment() {
 
     fun checkSharedPreference() {
         items = loadData()
-        myPageAdapter.submitList(items.toList())
+        uiData = uiData.subList(0, 2) + items.map { MyPageUiData.Video(it) }
+        myPageAdapter.submitList(uiData.toList())
     }
 
     private fun loadData():ArrayList<VideoForUi> {
@@ -168,5 +154,15 @@ class MyPageFragment : Fragment() {
             bookmarks.add(item)
         }
         return bookmarks
+    }
+
+    private fun setDetailFragment(item: VideoForUi) {
+        val dialog = DetailFragment.newInstance(item)
+        dialog.btnClick = object : BtnClick {
+            override fun click() {
+                checkSharedPreference()
+            }
+        }
+        dialog.show(requireActivity().supportFragmentManager, "DetailFragment")
     }
 }

--- a/app/src/main/java/com/example/meohaji/mypage/MyPageUiData.kt
+++ b/app/src/main/java/com/example/meohaji/mypage/MyPageUiData.kt
@@ -1,0 +1,16 @@
+package com.example.meohaji.mypage
+
+import com.example.meohaji.home.VideoForUi
+
+sealed class MyPageUiData {
+    data class Profile(
+        val name: String?,
+        val image: String?
+    ): MyPageUiData()
+
+    data object Title : MyPageUiData()
+
+    data class Video(
+        val video: VideoForUi
+    ): MyPageUiData()
+}

--- a/app/src/main/java/com/example/meohaji/mypage/SaveVideoAdapter.kt
+++ b/app/src/main/java/com/example/meohaji/mypage/SaveVideoAdapter.kt
@@ -1,0 +1,54 @@
+package com.example.meohaji.mypage
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.example.meohaji.databinding.ItemVideoByCategoryBinding
+import com.example.meohaji.home.VideoForUi
+
+
+class SaveVideoAdapter(private val context: Context) : ListAdapter<VideoForUi, SaveVideoAdapter.Holder>(
+    object : DiffUtil.ItemCallback<VideoForUi>() {
+        override fun areItemsTheSame(oldItem: VideoForUi, newItem: VideoForUi): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: VideoForUi, newItem: VideoForUi): Boolean {
+            return oldItem == newItem
+        }
+    }
+) {
+
+    inner class Holder(private val binding: ItemVideoByCategoryBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: VideoForUi) = with(binding) {
+            Glide.with(context)
+                .load(item.thumbnail)
+                .into(ivVideoByCategoryItemThumbnail)
+
+            tvVideoByCategoryItemTitle.text = item.title
+            tvVideoByCategoryItemChannelName.text = item.likeCount.toString()
+            tvVideoByCategoryItemUploadDate.text = item.viewCount.toString()
+            tvVideoByCategoryItemRecommendScore.text = item.recommendScore.toString()
+        }
+
+    }
+
+    override fun getItemCount(): Int {
+        return currentList.size
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
+        val binding = ItemVideoByCategoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return Holder(binding)
+    }
+
+    override fun onBindViewHolder(holder: Holder, position: Int) {
+        holder.bind(currentList[position])
+    }
+}
+

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -38,7 +38,7 @@
         android:id="@+id/view_pager_main"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/cv_main"
         app:layout_constraintTop_toBottomOf="@+id/toolbar_main" />
 
     <ImageView

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -7,98 +7,105 @@
     android:id="@+id/fl_myPageFrag"
     tools:context=".mypage.MyPageFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_my_page"
+        android:orientation="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent"/>
 
-        <de.hdodenhof.circleimageview.CircleImageView
-            android:id="@+id/civ_my_page_profile"
-            android:layout_width="200dp"
-            android:layout_height="200dp"
-            android:src="@drawable/ic_launcher_background"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginTop="20dp"
-            app:layout_constraintEnd_toEndOf="parent"/>
+<!--    <androidx.constraintlayout.widget.ConstraintLayout-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="wrap_content">-->
 
-        <Button
-            android:id="@+id/btn_my_page_editName"
-            android:layout_width="23dp"
-            android:layout_height="30dp"
-            app:layout_constraintTop_toTopOf="@id/civ_my_page_profile"
-            app:layout_constraintEnd_toEndOf="@id/civ_my_page_profile"
-            android:backgroundTint="@color/white"/>
+<!--        <de.hdodenhof.circleimageview.CircleImageView-->
+<!--            android:id="@+id/civ_my_page_profile"-->
+<!--            android:layout_width="200dp"-->
+<!--            android:layout_height="200dp"-->
+<!--            android:src="@drawable/ic_launcher_background"-->
+<!--            app:layout_constraintTop_toTopOf="parent"-->
+<!--            app:layout_constraintStart_toStartOf="parent"-->
+<!--            android:layout_marginTop="20dp"-->
+<!--            app:layout_constraintEnd_toEndOf="parent"/>-->
 
-        <TextView
-            android:id="@+id/tv_my_page_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Unknown"
-            android:textSize="24sp"
-            android:textStyle="bold"
-            app:layout_constraintTop_toBottomOf="@id/civ_my_page_profile"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="20dp"/>
+<!--        <Button-->
+<!--            android:id="@+id/btn_my_page_editName"-->
+<!--            android:layout_width="23dp"-->
+<!--            android:layout_height="30dp"-->
+<!--            app:layout_constraintTop_toTopOf="@id/civ_my_page_profile"-->
+<!--            app:layout_constraintEnd_toEndOf="@id/civ_my_page_profile"-->
+<!--            android:backgroundTint="@color/white"/>-->
 
-        <com.google.android.material.divider.MaterialDivider
-            android:layout_width="match_parent"
-            android:layout_height="0.5dp"
-            app:layout_constraintTop_toBottomOf="@id/tv_my_page_name"
-            app:layout_constraintBottom_toTopOf="@id/tv_my_page_saved_video"
-            app:dividerColor="#5B5B5B"
-            android:layout_marginHorizontal="15dp"/>
+<!--        <TextView-->
+<!--            android:id="@+id/tv_my_page_name"-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:text="Unknown"-->
+<!--            android:textSize="24sp"-->
+<!--            android:textStyle="bold"-->
+<!--            app:layout_constraintTop_toBottomOf="@id/civ_my_page_profile"-->
+<!--            app:layout_constraintStart_toStartOf="parent"-->
+<!--            app:layout_constraintEnd_toEndOf="parent"-->
+<!--            android:layout_marginTop="20dp"/>-->
 
-        <TextView
-            android:id="@+id/tv_my_page_saved_video"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="저장한 영상"
-            app:layout_constraintTop_toBottomOf="@id/tv_my_page_name"
-            app:layout_constraintStart_toStartOf="parent"
-            android:textSize="18sp"
-            android:layout_marginTop="30dp"
-            android:layout_marginStart="15dp"
-            android:fontFamily="@font/moyamoya"/>
-        <TextView
-            android:id="@+id/btn_clear_saved_video"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:clickable="true"
-            android:text="비우기"
-            android:padding="8dp"
-            app:layout_constraintTop_toTopOf="@id/tv_my_page_saved_video"
-            app:layout_constraintBottom_toBottomOf="@id/tv_my_page_saved_video"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:textSize="18sp"
-            android:layout_marginEnd="15dp"
-            android:fontFamily="@font/moyamoya"/>
+<!--        <com.google.android.material.divider.MaterialDivider-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="0.5dp"-->
+<!--            app:layout_constraintTop_toBottomOf="@id/tv_my_page_name"-->
+<!--            app:layout_constraintBottom_toTopOf="@id/tv_my_page_saved_video"-->
+<!--            app:dividerColor="#5B5B5B"-->
+<!--            android:layout_marginHorizontal="15dp"/>-->
 
-        <TextView
-            android:id="@+id/btn_refresh_saved_video"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:clickable="true"
-            android:text="새로고침"
-            android:padding="8dp"
-            app:layout_constraintTop_toTopOf="@id/tv_my_page_saved_video"
-            app:layout_constraintBottom_toBottomOf="@id/tv_my_page_saved_video"
-            app:layout_constraintEnd_toStartOf="@id/btn_clear_saved_video"
-            android:textSize="18sp"
-            android:layout_marginEnd="15dp"
-            android:fontFamily="@font/moyamoya"/>
+<!--        <TextView-->
+<!--            android:id="@+id/tv_my_page_saved_video"-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:text="저장한 영상"-->
+<!--            app:layout_constraintTop_toBottomOf="@id/tv_my_page_name"-->
+<!--            app:layout_constraintStart_toStartOf="parent"-->
+<!--            android:textSize="18sp"-->
+<!--            android:layout_marginTop="30dp"-->
+<!--            android:layout_marginStart="15dp"-->
+<!--            android:fontFamily="@font/moyamoya"/>-->
+<!--        <TextView-->
+<!--            android:id="@+id/btn_clear_saved_video"-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:clickable="true"-->
+<!--            android:text="비우기"-->
+<!--            android:padding="8dp"-->
+<!--            app:layout_constraintTop_toTopOf="@id/tv_my_page_saved_video"-->
+<!--            app:layout_constraintBottom_toBottomOf="@id/tv_my_page_saved_video"-->
+<!--            app:layout_constraintEnd_toEndOf="parent"-->
+<!--            android:textSize="18sp"-->
+<!--            android:layout_marginEnd="15dp"-->
+<!--            android:fontFamily="@font/moyamoya"/>-->
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_my_page"
-            android:layout_marginTop="8dp"
-            android:layout_width="match_parent"
-            android:overScrollMode="never"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/tv_my_page_saved_video"/>
+<!--        <TextView-->
+<!--            android:id="@+id/btn_refresh_saved_video"-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:clickable="true"-->
+<!--            android:text="새로고침"-->
+<!--            android:padding="8dp"-->
+<!--            app:layout_constraintTop_toTopOf="@id/tv_my_page_saved_video"-->
+<!--            app:layout_constraintBottom_toBottomOf="@id/tv_my_page_saved_video"-->
+<!--            app:layout_constraintEnd_toStartOf="@id/btn_clear_saved_video"-->
+<!--            android:textSize="18sp"-->
+<!--            android:layout_marginEnd="15dp"-->
+<!--            android:fontFamily="@font/moyamoya"/>-->
+
+<!--        <androidx.recyclerview.widget.RecyclerView-->
+<!--            android:id="@+id/rv_my_page"-->
+<!--            android:layout_marginTop="8dp"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:overScrollMode="never"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            app:layout_constraintTop_toBottomOf="@id/tv_my_page_saved_video"/>-->
 
 
 
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+<!--    </androidx.constraintlayout.widget.ConstraintLayout>-->
 
-</ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_my_profile.xml
+++ b/app/src/main/res/layout/layout_my_profile.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/black_background"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <de.hdodenhof.circleimageview.CircleImageView
+        android:id="@+id/civ_my_page_profile"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        android:src="@drawable/ic_launcher_background"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginTop="20dp"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <Button
+        android:id="@+id/btn_my_page_editName"
+        android:layout_width="23dp"
+        android:layout_height="30dp"
+        app:layout_constraintTop_toTopOf="@id/civ_my_page_profile"
+        app:layout_constraintEnd_toEndOf="@id/civ_my_page_profile"
+        android:backgroundTint="@color/white"/>
+
+    <TextView
+        android:id="@+id/tv_my_page_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Unknown"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toBottomOf="@id/civ_my_page_profile"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="20dp"/>
+
+    <com.google.android.material.divider.MaterialDivider
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:layout_marginTop="15dp"
+        app:layout_constraintTop_toBottomOf="@id/tv_my_page_name"
+        app:dividerColor="#5B5B5B"
+        android:layout_marginHorizontal="15dp"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_save_video_title.xml
+++ b/app/src/main/res/layout/layout_save_video_title.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/black_background">
+
+    <TextView
+        android:id="@+id/tv_my_page_saved_video"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="15dp"
+        android:layout_marginTop="15dp"
+        android:layout_marginBottom="15dp"
+        android:fontFamily="@font/moyamoya"
+        android:text="저장한 영상"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/btn_clear_saved_video"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="15dp"
+        android:clickable="true"
+        android:fontFamily="@font/moyamoya"
+        android:padding="8dp"
+        android:text="비우기"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toBottomOf="@id/tv_my_page_saved_video"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tv_my_page_saved_video" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [ ] 기능구현
- [ ] 버그픽스
- [x] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃

## 변경사항 작성
변경사항의 상세 정보를 작성해주세요.

-기능
refactor : 마이 페이지 멀티뷰타입 리사이클러뷰로 변경
-설명
상단 프로필 부분
중단 타이틀 부분
하단 비디오 영역
으로 나눠서 리사이클러뷰를 구성(이를 위해 sealed class 생성하고 레이아웃도 만듬) 하단 비디오 영역은 리사이클러뷰를 넣는 것이 아닌 비디오 하나하나를 넣음
인터페이스를 추가하여 프로필 편집 다이얼로그 이벤트와 상세 프래그먼트 이벤트 처리
편집 다이얼로그에서 이미지를 선택하지 않고 그냥 확인을 눌렀을 때 빈 이미지 화면으로 나오는 문제가 있었는데 처음에 selectedImageUri 값을 주니까 해결됨 기존에 쓰던 어댑터는 SaveVideoAdapter로 이름을 바꿔 재활용함

*추가한 부분 : 메인 액티비티 레이아웃 xml에서 뷰페이저를 카드뷰 위쪽으로 얹었다.